### PR TITLE
In selection mode, include the selected target character

### DIFF
--- a/src/org/hunmr/acejump/command/CommandAroundJump.java
+++ b/src/org/hunmr/acejump/command/CommandAroundJump.java
@@ -24,9 +24,10 @@ public class CommandAroundJump {
 
     protected void selectJumpArea(int jumpTargetOffset) {
         if (getOffsetBeforeJump() < jumpTargetOffset) {
-            _editor.getSelectionModel().setSelection(getOffsetBeforeJump(), jumpTargetOffset);
+            _editor.getSelectionModel().setSelection(getOffsetBeforeJump(), jumpTargetOffset + 1);
+            _editor.getCaretModel().moveToOffset(jumpTargetOffset + 1);
         } else {
-            _editor.getSelectionModel().setSelection(jumpTargetOffset, getOffsetBeforeJump());
+            _editor.getSelectionModel().setSelection(jumpTargetOffset, getOffsetBeforeJump() + 1);
         }
     }
 


### PR DESCRIPTION
For instance when the cursor is before the "a" in "abcde" and the user jumps to the "d" it would select [abcd]e instead of [abc]